### PR TITLE
LoadError is not inherited from StandardError anymore. 

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -22,7 +22,7 @@ In your Rakefile, load Vlad with the :scm => :git:
  begin
    require 'vlad'
    Vlad.load :scm => :git
- rescue
+ rescue LoadError
    # do nothing
  end
 


### PR DESCRIPTION
A plain rescue doesn't work anymore.
