### PR TITLE
Repo creation does not respect 'umask' setting

### DIFF
--- a/lib/vlad/git.rb
+++ b/lib/vlad/git.rb
@@ -30,6 +30,7 @@ class Vlad::Git
       [ "umask #{umask}",
         "rm -rf #{destination}",
         "#{git_cmd} clone #{repository} #{destination}",
+        "chmod $(expr 777 - `umask`) #{destination}",
         "cd #{destination}",
         "#{git_cmd} checkout -f -b deployed-#{revision} #{revision}",
         submodule_cmd,

--- a/lib/vlad/git.rb
+++ b/lib/vlad/git.rb
@@ -16,7 +16,8 @@ class Vlad::Git
     new_revision = ('HEAD' == revision) ? "origin" : revision
 
     if fast_checkout_applicable?(revision, destination)
-      [ "cd #{destination}",
+      [ "umask #{umask}",
+        "cd #{destination}",
         "#{git_cmd} checkout -q origin",
         "#{git_cmd} fetch",
         "#{git_cmd} reset --hard #{new_revision}",
@@ -26,7 +27,8 @@ class Vlad::Git
         "cd -"
       ].join(" && ")
     else
-      [ "rm -rf #{destination}",
+      [ "umask #{umask}",
+        "rm -rf #{destination}",
         "#{git_cmd} clone #{repository} #{destination}",
         "cd #{destination}",
         "#{git_cmd} checkout -f -b deployed-#{revision} #{revision}",
@@ -44,7 +46,8 @@ class Vlad::Git
     revision = 'HEAD' if revision =~ /head/i
     revision = "deployed-#{revision}"
 
-    [ "mkdir -p #{destination}",
+    [ "umask #{umask}",
+      "mkdir -p #{destination}",
       "cd repo",
       "#{git_cmd} archive --format=tar #{revision} | (cd #{destination} && tar xf -)",
       "#{git_cmd} submodule foreach '#{git_cmd} archive --format=tar $sha1 | (cd #{destination}/$path && tar xf -)'",


### PR DESCRIPTION
This request fixes the umask settings not applying correctly by adding a "umask" command to the head of commands that create files.  Additionally, it addresses a bug in git where "git clone" does not respect the user's umask settings for the project folder.
